### PR TITLE
Fix highlighter & capitalised category

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Dependencies
 markdown:         redcarpet
-highlighter:      pygments
+highlighter:      rouge
 
 # Permalinks
 permalink:        pretty

--- a/_posts/2014-10-16-file-formats.md
+++ b/_posts/2014-10-16-file-formats.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: The Joy of File Formats
-categories: File-formats
+categories: file-formats
 ---
 
 ###What's the problem?


### PR DESCRIPTION
See https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors and also I noticed when checking the live page that we'd ended up with two file formats categories because they are case sensitive.

