### PR TITLE
Making markdown kramdown compatible

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Dependencies
-markdown:         redcarpet
+markdown:         kramdown
 highlighter:      rouge
 
 # Permalinks

--- a/_drafts/draft.md
+++ b/_drafts/draft.md
@@ -8,17 +8,18 @@ Then merrily add some text using markdown e.g *this is italics*, **this is bold*
 
 If you want titles within a post, headings are
 
-#Top level
+# Top level
 
-##Subtitle
+## Subtitle
 
-###Another another level if needed
+### Another another level if needed
 
 To add an image, save it into the image folder and then insert using
 ![alt text](/images/yourimage.png)
 
 See a markdown guide such as [this one here](https://daringfireball.net/projects/markdown/basics)
-if you need further formatting help.
+if you need further formatting help. The markdown engine for GitHub pages is
+now kramdown, a [quick reference guide is available](http://kramdown.gettalong.org/quickref.html).
 
 Or see [poole example content file](https://github.com/poole/poole/blob/master/_posts/2014-01-01-example-content.md)
 for what types of more technical formatting are supported by this theme.

--- a/_posts/2014-10-16-file-formats.md
+++ b/_posts/2014-10-16-file-formats.md
@@ -4,7 +4,7 @@ title: The Joy of File Formats
 categories: file-formats
 ---
 
-###What's the problem?
+### What's the problem?
 
 Imaging technology-- including probes and molecular reporters, acquisition
 systems, and data analysis tools-- is one of the great success stories of
@@ -30,7 +30,7 @@ limiting factor in making a scientific discovery.
 
 Thus, this Blog, and our first topic, File Formats.
 
-###Image data and metadata
+## Image data and metadata
 
 A digital image is written to disk in a *file format* that stores the *pixel*
 data (sometimes referred to as the binary data) and the *image metadata*. This
@@ -50,7 +50,7 @@ measurements or other analytic results. In OME, we call anything saved in an
 incoming file format "image metadata". As we will see, this is a very broad
 definition, but it is probably the only viable one to use.
 
-###What's a file format?
+## What's a file format?
 
 A file format is a mechanism for storing data on digital media. It's a defined
 way to read and write the pixel data and image metadata produced by a specific
@@ -64,7 +64,7 @@ available. Most are private, in the sense that they are not openly documented
 and supported, so in OME, we refer to these as *proprietary file formats*
 (PFFs).
 
-###Data standards and lossy data storage
+## Data standards and lossy data storage
 
 So why isn't there a single standard for image files?
 
@@ -119,7 +119,7 @@ standard, "private fields" are used by the commercial imaging system
 manufacturers to store proprietary metadata hidden from view from standard
 image viewers.
 
-###How different are different file formats?
+## How different are different file formats?
 
 Almost all file formats use an established or known standard-- for example,
 TIFF to store the pixel data, XML to store metadata and so on. Several use
@@ -158,7 +158,7 @@ which is especially inconvenient for the user. With a few hundred different
 imaging systems currently available, each with a few updates per year, it's no
 wonder that users [report spending so much time dealing with image file formats](http://www.eurobioimaging.eu/sites/default/files/D11.1%20State%20of%20the%20art%20and%20community%20requirements%20in%20Biomedical%20Image%20Analysis,%20Storage%20and%20Remote%20%20Access.pdf).
 
-###What to do?
+## What to do?
 
 So, if data format standardization is not really possible, what’s the
 solution? In 2002, Kevin Eliceiri and Curtis Rueden (LOCI, Madison), proposed

--- a/_posts/2014-10-23-common-interface.md
+++ b/_posts/2014-10-23-common-interface.md
@@ -4,7 +4,7 @@ title: The OME Approach to a Common Interface
 categories: file-formats data-model
 ---
 
-###Introduction
+## Introduction
 
 In the previous entry, we examined the challenges presented by supporting a
 wide variety of file formats that represent data outputs in the rapidly
@@ -17,7 +17,7 @@ this entry, we discuss the technical foundation for Bio-Formats and how it
 provides a single metadata description that is both well-defined and
 extensible.
 
-###The OME Data Model
+## The OME Data Model
 
 A common interface for accessing image data requires a known specification for
 that data. When OME started (around 2001) there weren’t any defined
@@ -57,7 +57,7 @@ specification for converting and also writing image data. Any software tool
 that uses Bio-Formats has access to
 [all the formats Bio-Formats supports](http://www.openmicroscopy.org/site/support/bio-formats/supported-formats.html).
 
-###Multi-dimensional data
+## Multi-dimensional data
 
 From its earliest versions, the OME Data Model supported a 5D image, including
 3 spatial dimensions, time, and frequency (often referred to as “channel”).
@@ -86,7 +86,7 @@ several groups on this problem. In particular, we are following the
 [ImgLib2](http://imglib2.net) project's work on building an N-dimensional
 image library.
 
-###A least common denominator
+## A least common denominator
 
 As noted in our first entry to this blog, conversion of original metadata into
 some kind of common model inherently risks data loss. There is a compromise
@@ -106,7 +106,7 @@ stored and accessed by any application, while application-specific metadata
 can be stored and will be accessible to third parties if the appropriate
 specification is made available.
 
-###A frustratingly incomplete, always obsolete, amazingly effective solution
+## A frustratingly incomplete, always obsolete, amazingly effective solution
 
 Using a common specification that cannot specify every advanced,
 cutting edge biological imaging system results in a solution that is always

--- a/_posts/2014-11-14-partnership.md
+++ b/_posts/2014-11-14-partnership.md
@@ -11,7 +11,7 @@ and Bio-Formats, to explain OME’s efforts to deliver a common library for
 accessing scientific image data. In this next entry, we describe how we work
 with the community to build Bio-Formats.
 
-###For the community
+## For the community
 
 [Bio-Formats](http://www.openmicroscopy.org/site/products/bio-formats) is a
 Java library, available under an open source license
@@ -31,7 +31,7 @@ flexibility has resulted in substantial uptake of Bio-Formats — it is
 installed in many thousands of sites worldwide and started more than 10,000
 times each day.
 
-###By the community
+## By the community
 
 The success of the Bio-Formats project is heartening, but what really
 differentiates it is the way its development process links in with the
@@ -72,7 +72,7 @@ hold are at best barely up-to-date with the latest changes in file formats and
 the newest imaging technologies. It is however unquestionably a great
 reference for our work.
 
-###On Convergence and Diversity…
+## On Convergence and Diversity…
 
 Rarely a day goes by where the OME Team is not contacted for
 [some issue or problem](https://www.openmicroscopy.org/community/viewforum.php?f=13)
@@ -100,7 +100,7 @@ we have for improving this situation is working more closely with some of the
 commercial vendors to get a better specification of how their different
 imaging systems are supported in their file formats.
 
-###Expanding the domains
+## Expanding the domains
 
 Over the years the OME Data Model has grown to support many different imaging
 modalities. In the near future, OME’s goal is to continue to expand the
@@ -119,7 +119,7 @@ This is part of an explicit effort to build the foundation for expanding
 Bio-Formats capabilities into new domains and to express the linkages between
 different domains.
 
-###Being a Partner
+## Being a Partner
 
 One of the challenges of building and maintaining Bio-Formats is the scale of
 its user community. The number of requests that arrive on a daily basis for
@@ -142,7 +142,7 @@ different PFFs to different individuals and entities, while maintaining the
 commitment to code review, QA and testing that we have developed over the last
 several years. Watch this space… or maybe get involved!
 
-###The infinite backlog…
+## The infinite backlog…
 
 As noted above, the rapid pace of innovation and scale of usage means that the
 Bio-Formats team is always facing a
@@ -160,7 +160,7 @@ and is always welcome to contact the team to check on status. Repeated
 requests from a single individual do count, but we are strongly influenced by
 similar requests from multiple individuals.
 
-###Meeting the challenge together
+## Meeting the challenge together
 
 As we work to provide a single common access mechanism for scientific image
 data, please do [send us examples](http://qa.openmicroscopy.org.uk/qa/upload/)

--- a/_posts/2015-01-13-bf-update.md
+++ b/_posts/2015-01-13-bf-update.md
@@ -6,7 +6,7 @@ categories: file-formats data-model future-plans
 
 Current development on Bio-Formats can be grouped into four categories:
 
-###Model changes
+### Model changes
 
 Through our 4.4.x and 5.0.x releases (July 2012-present), we’ve held the OME
 Data Model and all interfaces largely constant, primarily to support the large
@@ -46,7 +46,7 @@ Examples include:
    between different images, e.g. in correlative imaging, so we must have this
    capability.
 
-###C++ implementation
+### C++ implementation
 
 For OME 5.1 we are releasing a native C++ implementation for Bio-Formats. The
 goal here is to make it easier to call Bio-Formats from a non-Java program.
@@ -63,7 +63,7 @@ forward to adding specific readers that will benefit the community.
 *Disclaimer: not all, or even most, of the Java-based Bio-Formats will be
 ported to C++.*
 
-###Format fixes
+### Format fixes
 
 As always we have been working on fixing several formats. This work has been
 complicated by the number of imaging modalities which are appearing inside in
@@ -71,14 +71,14 @@ each individual file format (see [previous blog post](http://blog.openmicroscopy
 Our work is focused on ND2, MetaMorph, Prairie, DICOM, Zeiss CZI, and Leica
 LIF. We also have added support for the i2i and im3 formats.
 
-###Performance
+### Performance
 
 Dataset sizes continue to increase by several-fold, so Bio-Formats’
 capabilities have to keep up. For the 5.1 release, we’ve reduced the
 overhead for metadata parsing, improved I/O buffering, and tuned Zeiss CZI and
 several HCS readers to have faster initialization and plane reading times.
 
-##Looking a bit further forward...
+## Looking a bit further forward...
 
 After the 5.1 release, we of course have several more things we are
 considering. To get changes to Bio-Formats out to the community as rapidly as

--- a/_posts/2015-07-21-java-issue.md
+++ b/_posts/2015-07-21-java-issue.md
@@ -9,7 +9,7 @@ after a Java upgrade, it was no longer possible to connect to the OMERO server
 using OMERO.insight. Since then we’ve been looking into the issue. A fix is
 ready as well as a few steps for the future.
 
-##Background
+## Background
 
 A recent security vulnerability in Java
 
@@ -27,7 +27,7 @@ connecting to an OMERO server due to a handshake error in Ice. Since the
 router used by OMERO (Glacier2) is not written in Java, just updating the Java
 version on the server is not enough to prevent the issue.
 
-##Workaround
+## Workaround
 
 Instead, a small configuration change is needed in OMERO. This will remove the
 no-longer supported ciphers, allowing both old and new OMERO clients, whether
@@ -48,7 +48,7 @@ take the following steps:
 >patching file etc/grid/templates.xml  
 >$ bin/omero admin deploy
 
-##What we're doing about it
+## What we're doing about it
 
 The patch above will be included in the next release of OMERO (5.1.3) but we
 are providing it in the meantime for users currently completely blocked by

--- a/_posts/2015-09-23-java-web-start.md
+++ b/_posts/2015-09-23-java-web-start.md
@@ -18,7 +18,7 @@ As such, we will be deprecating Java Web Start in the upcoming 5.1.4 release and
 
 Below we discuss the technical background behind this decision in more detail.
 
-##Background
+## Background
 
 Java Web Start was introduced in 2001 to allow applications to be launched through browsers or directly via the Java Network Launching Protocol (JNLP).
 
@@ -35,7 +35,7 @@ Rich Internet Applications must contain two things:
 
 Due to vulnerabilities affecting Java plugins, security experts frequently recommend users disable Java at least in their browser. Since 2013, Firefox, Google Chrome and other browsers have started to block plugins by default.
 
-##What does it mean for desktop developers/administrators?
+## What does it mean for desktop developers/administrators?
 
 To deploy Java Web Start, one first needs to get familiar with [Deployment Rule Sets](https://blogs.oracle.com/java-platform-group/entry/introducing_deployment_rule_sets).
 Administrators can then create a list of known-safe applications and manage compatibility between
@@ -44,7 +44,7 @@ Each browser will have their own set of dialogs and control mechanisms.
 
 It is getting harder and harder to distribute Java Web Start applications for developers and/or administrators.
 
-##What about Browser support?
+## What about Browser support?
 
 The Java plugin for web browsers relies on the cross-platform plugin architecture [NPAPI](https://en.wikipedia.org/wiki/NPAPI), which has been supported by all major web browsers for the past 10 years.
 In version 45 (released Sept 2015), Google Chrome has dropped support for [NPAPI plugins like Java](https://support.google.com/chrome/answer/6213033).

--- a/_posts/2015-10-15-java-6.md
+++ b/_posts/2015-10-15-java-6.md
@@ -8,14 +8,14 @@ Following our [published roadmap for Java support](http://www.openmicroscopy.org
 we are ending support for Java 6 with the release of OMERO and Bio-Formats 5.2
 later this year.
 
-##We are not alone
+## We are not alone
 
 This will potentially affect users of the ImageJ plugins for Bio-Formats and
 OMERO-ImageJ (OMERO.ij). Note that Java 6 has been unsupported since February
 2013 and will [no longer work with MacOS X after 10.11](https://developer.apple.com/library/prerelease/mac/releasenotes/General/rn-osx-10.11/).
 This change is also being made by other ImageJ plugin developers.
 
-##Version support
+## Version support
 
 Our current and planned support for Java 6 and Java 7 is as follows:
 
@@ -36,14 +36,14 @@ Our current and planned support for Java 6 and Java 7 is as follows:
         <td>5.2 (forthcoming)</td>
         <td>1.7</td>
     </tr>
-<table>
+</table>
 
 The change for 5.2 will affect ImageJ and Fiji with a bundled version
 of Java 6, and users of non-bundled ImageJ and Fiji who
 have Java 6 provided by the operating system (this includes older
 Linux distributions providing OpenJDK6).
 
-##What to do
+## What to do
 
 In all cases, it should be possible to download a 1.7 or 1.8 JRE for
 your platform from
@@ -57,7 +57,7 @@ the [5.1 release](http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/
 **If you upgrade the system's version of Java, you can then run a
 version of ImageJ or Fiji without a bundled JVM.**
 
-###ImageJ bundle users
+### ImageJ bundle users
 
 Users of ImageJ with a bundled JVM may [download a new version](http://imagej.nih.gov/ij/download.html) either using the "platform
 independent" version without a bundled JRE, or download the MacOS X or
@@ -65,14 +65,14 @@ Windows versions with a bundled Java 8. These are marked as
 experimental, but our testing has shown them to be perfectly
 functional with the Bio-Formats and OMERO.ij plugins.
 
-###Fiji users
+### Fiji users
 
 Fiji for "all platforms (no JREs)" will work with the system Java 7 or
 Java 8. The Fiji downloads for individual platforms currently provide
 Java 6, but will be bundled with Java 8 in the near future.
 For now, the "all platforms (no JREs)" download is recommended.
 
-##If you can't upgrade
+## If you can't upgrade
 
 Users who are unable or unwilling to upgrade their Java to version 7
 or later will be able to continue to use the 5.1 and earlier releases

--- a/_posts/2015-12-09-omero-status.md
+++ b/_posts/2015-12-09-omero-status.md
@@ -7,7 +7,7 @@ categories: future-plans community
 This is a quick update on the status of various versions of OMERO, and some
 discussion about our future development plans and aspirations.
 
-##Releases, maintenance and deprecation
+## Releases, maintenance and deprecation
 
 With the [release of OMERO 5.2.0](https://www.openmicroscopy.org/community/viewtopic.php?f=11&t=7922) at
 the beginning of November 2015, the current situation with OMERO versions is
@@ -44,7 +44,7 @@ We recognise that often groups wishing to use OMERO do not have access to a
 dedicated sysadmin and are trying to alleviate the burden as much as possible.
 You can follow progress on the [OMERO 5.2.1 board](https://trello.com/b/HdHaudmw/omero-5-2-1).
 
-##What’s next?
+## What’s next?
 
 With OMERO’s use expanding in numbers and in breadth of domains, we are
 focussing our efforts on making OMERO even more powerful - ensuring that it

--- a/_posts/2016-01-06-format-support.md
+++ b/_posts/2016-01-06-format-support.md
@@ -9,7 +9,7 @@ about when we expect to support 3D HISTECH .mrxs files. This sort of request
 isn’t particularly unusual and the reply gives an insight into one of the key 
 challenges we face.
 
-##Just because we don’t have a reader, doesn’t mean we haven’t done any work
+## Just because we don’t have a reader, doesn’t mean we haven’t done any work
 
 3D HISTECH .mrxs is an example of a complex format, the design of which does
 not make our work any easier. In fact, we can say with some confidence that
@@ -35,7 +35,7 @@ obviously the work to produce it started even further back than that). Nikon
 ND2 and Zeiss CZI are other examples of formats with a complex design that
 makes them very difficult for us to support.
 
-##We won’t deliver something that doesn’t do the job well enough
+## We won’t deliver something that doesn’t do the job well enough
 
 One thing to understand about our work, strategy and commitment to supporting
 all file formats, especially formats used in production-scale facilities that
@@ -70,7 +70,7 @@ requires time consuming and computationally expensive reprocessing and pyramid
 creation, just because of the implementation choices made by the format
 designers.
 
-##A philosophical point about our funding and resources
+## A philosophical point about our funding and resources
 
 The OME Consortium and the wider development community have worked steadily
 since 2002, funded mostly by grants from non-profit charities and public
@@ -103,7 +103,7 @@ applaud this trend; ultimately it means scientists, clinicians, engineers and
 developers spend less time dealing with data formats and more time doing
 science, developing new technologies and treating patients.
 
-##What you can do
+## What you can do
 
 The community has the power to change this situation. You are paying for these
 proprietary formats. You can condition your purchase, continued payment of

--- a/_posts/2016-01-26-bf-model-status.md
+++ b/_posts/2016-01-26-bf-model-status.md
@@ -8,7 +8,7 @@ This is an update about what we are working on in the Bio-Formats codebase for
 the next few months. As this is where the OME Data Model lives, it covers our
 current and upcoming work on the Model and the Bio-Formats project.
 
-##Current Bio-Formats development focus
+## Current Bio-Formats development focus
 
 The release of [5.1.7 back in December](http://www.openmicroscopy.org/site/news/release-of-bio-formats-5.1.7)
 is likely to be the last regularly planned release of Bio-Formats 5.1.x.
@@ -27,7 +27,7 @@ For developers using Bio-Formats, the develop branch will include development sc
 We hope to release Bio-Formats version 5.2.0 in Spring 2016. You can follow
 our progress on the [public Trello board](https://trello.com/b/OHTqY4pc/bio-formats-5-2-0).
 
-##Data Model work
+## Data Model work
 
 The main effort of the Bio-Formats 5.2.0 development work will be focused on
 updating the Data Model to include a folder-like structure for storing Regions
@@ -61,7 +61,7 @@ about this in a later entry. In brief, our aim is to package and release all
 the work we’ve done on the Image Data Repository as tools for the community to
 use to access a broad range of types of metadata.
 
-##New format support
+## New format support
 
 Despite the focus on the Data Model, 5.2.0 will also introduce two new
 formats. These are scheduled to be Becker & Hickl SPC and Princeton
@@ -83,7 +83,7 @@ releases so the whole community can follow what is upcoming (these will be
 listed on the [Getting Started Trello board](https://trello.com/b/4EXb35xQ/getting-started)).
 
 
-##OME-Files
+## OME-Files
 
 The OME Data Model and Bio-Formats C++ will be decoupled from the main
 Bio-Formats code repository and renamed as OME-Files. This new API will

--- a/_posts/2016-03-22-windows-support.md
+++ b/_posts/2016-03-22-windows-support.md
@@ -25,7 +25,7 @@ Windows, OMERO.web browsing on IE and continue to provide full support for
 Bio-Formats on Windows (including the C++ components of this project). The
 reasons for this decision are outlined below.
 
-##Ever-increasing technical challenges
+## Ever-increasing technical challenges
 
 Our Continuous Integration (CI) system uses [Travis](https://travis-ci.org/)
 and allows the OME Consortium’s work to be built and tested on a per-commit


### PR DESCRIPTION
karmdown flavoured markdown didn't like me not leaving a space between the hashes and the text in subheadings. I also discovered a missing close-html-tag when checking the build locally (for some reason this was ignored by the old markdown but as soon as I stuck the space in, the rendering engine didn't recognise the rest of the page as markdown).

To test, fetch branch and build locally using jekyll 3, then skim read all the blog posts to check the formatting is all correct (bug noticed was that all the subheadings were rendering as normal text with the hashes at the beginning). OR use your local repo with the CNAME and baseurl fixed so it builds to your local gh-pages URL.
