### PR TITLE
C++: Correct typo

### DIFF
--- a/_posts/2016-12-05-files-cpp.md
+++ b/_posts/2016-12-05-files-cpp.md
@@ -48,7 +48,7 @@ Most current platforms support C++11 and C++14, with some exceptions
 
 ‡ Microsoft Visual C++ lags significantly behind GCC and Clang/LLVM,
   but VS2013 contains a useful subset of features, which are improved
-  upon significantly with VC2015 and later
+  upon significantly with VS2015 and later
 
 The support classifications above are broad; please see the following
 references for full feature coverage:


### PR DESCRIPTION
VC should be VS.