### PR TITLE
Add twitter preview image

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,8 @@
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta name="twitter:image" content="{{ site.baseurl }}">
+  <meta name="twitter:card" content="{{ site.baseurl }}/images/ome-logo-on-white-200.png">
 
   <!-- Enable responsiveness on mobile devices-->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">


### PR DESCRIPTION
Copies strategy of https://github.com/openmicroscopy/www.openmicroscopy.org/pull/183 to add the logo to the twitter preview when posting links.

I haven't added a title or description as that is already working and it's nice to have the post title and preview rather than a static one.