### PR TITLE
Specify vizarr version in recent blog posts

### DIFF
--- a/_posts/2020-11-04-zarr-data.md
+++ b/_posts/2020-11-04-zarr-data.md
@@ -24,7 +24,7 @@ Below are listed Images converted into version 0.1 of the OME-Zarr spec. This li
 We are currently working on a spec for representing HCS data in OME-Zarr. When this spec is finalised, we
 will also provide links to sample HCS data in this format.
 
-<iframe style="width: 100%; height: 500px" name="vizarr" src="https://hms-dbmi.github.io/vizarr?source=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836831.zarr">
+<iframe style="width: 100%; height: 500px" name="vizarr" src="https://hms-dbmi.github.io/vizarr/v0.1/?source=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836831.zarr">
 </iframe>
 
 <div class="row">
@@ -59,7 +59,7 @@ will also provide links to sample HCS data in this format.
                         <td>{{ row.C }} </td>
                         <td>{{ row.T }} </td>
                         <td>
-                            <a title="Open in viewer above" target='vizarr' href="https://hms-dbmi.github.io/vizarr?source=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/{{ row.Image }}.zarr">
+                            <a title="Open in viewer above" target='vizarr' href="https://hms-dbmi.github.io/vizarr/v0.1/?source=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/{{ row.Image }}.zarr">
                                 view
                             </a>
                         </td>

--- a/_posts/2020-12-01-zarr-hcs.md
+++ b/_posts/2020-12-01-zarr-hcs.md
@@ -24,7 +24,7 @@ at the [European Bioinformatics Institute (EBI)](https://www.ebi.ac.uk/).
 
 Below is an example of a visual representation of an OME-Zarr plate using the [vizarr](https://github.com/hms-dbmi/vizarr) viewer.
 
-<iframe style="width: 100%; height: 500px" name="vizarr" src="https://hms-dbmi.github.io/vizarr?source=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/5966.zarr">
+<iframe style="width: 100%; height: 500px" name="vizarr" src="https://hms-dbmi.github.io/vizarr/v0.1/?source=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/5966.zarr">
 </iframe>
 
 The table below list all plates converted into version 0.1 of the OME-Zarr spec. This list is also available in
@@ -58,7 +58,7 @@ The table below list all plates converted into version 0.1 of the OME-Zarr spec.
                         <td>{{ row.fields }} ( {{ row.acquisitions }}) </td>
                         <td>{{ row.dimensions }} </td>
                         <td>
-                            <a title="Open in viewer above" target='vizarr' href="https://hms-dbmi.github.io/vizarr?source=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/{{ row.id }}.zarr">
+                            <a title="Open in viewer above" target='vizarr' href="https://hms-dbmi.github.io/vizarr/v0.1/?source=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/{{ row.id }}.zarr">
                                 view
                             </a>
                         </td>


### PR DESCRIPTION
@manzt pointed out that a large refactoring of Viv is
about to drop. Hard-coding the version for these URLs
to prevent breakages.

cc: @will-moore